### PR TITLE
feat: Implement man-aura-app-plugin detection

### DIFF
--- a/app/app.gradle.kts
+++ b/app/app.gradle.kts
@@ -1,0 +1,1 @@
+// app build configuration

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -72,3 +72,10 @@ tasks.register<Delete>("clean") {
     delete("${projectDir}/build")
     delete("${projectDir}/.idea")
 }
+
+// Apply the man-aura-app-plugin if it was detected in buildSrc
+if (project.extra.has("hasManAuraAppPlugin")) {
+    allprojects {
+        apply(plugin = "man-aura-app-plugin")
+    }
+}

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -22,3 +22,14 @@ kotlin {
         jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21
     }
 }
+
+// Logic to detect and configure the man-aura-app-plugin
+val pluginDir = rootProject.file("plugins")
+val pluginName = "man-aura-app-plugin"
+val pluginFound = pluginDir.listFiles()?.any { it.name.contains(pluginName) } == true
+
+if (pluginFound) {
+    println("Detected $pluginName! Configuring project accordingly.")
+    // Set an extra property to be used in other build scripts
+    extra.set("hasManAuraAppPlugin", true)
+}


### PR DESCRIPTION
This commit implements the logic to detect the presence of the `man-aura-app-plugin` in the `plugins` directory and configure the multi-module project accordingly.

The changes include:
- Added logic to `buildSrc/build.gradle.kts` to scan the `plugins` directory and set an extra property `hasManAuraAppPlugin` if the plugin is found.
- Modified the root `build.gradle.kts` to apply the `man-aura-app-plugin` to all subprojects if the `hasManAuraAppPlugin` property is set.